### PR TITLE
Added sort parameter to /version endpoint - closes #31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `/metrics` endpoint
 - Enabled access logs
 - [#24](https://github.com/devatherock/artifactory-badge/issues/24): Unit tests for 100% code coverage
+- [#31](https://github.com/devatherock/artifactory-badge/issues/31): `sort` parameter to `/version` endpoint with default value as `date`. With value `semver`, it'll pull the latest out of only semantic version tags
 
 ### Changed
 - Caught exception when JSON processing fails

--- a/src/main/java/io/github/devatherock/artifactory/controllers/VersionController.java
+++ b/src/main/java/io/github/devatherock/artifactory/controllers/VersionController.java
@@ -28,12 +28,14 @@ public class VersionController {
      * 
      * @param packageName
      * @param badgeLabel
+     * @param sort
      * @return the version badge
      */
     @Get(value = "/version", produces = CONTENT_TYPE_BADGE)
     public String getLatestVersion(@QueryValue("package") String packageName,
-                                   @QueryValue(value = "label", defaultValue = "version") String badgeLabel) {
+                                   @QueryValue(value = "label", defaultValue = "version") String badgeLabel,
+                                   @QueryValue(value = "sort", defaultValue = "date") String sortType) {
         LOGGER.debug("In getLatestVersion");
-        return badgeService.getLatestVersionBadge(packageName, badgeLabel);
+        return badgeService.getLatestVersionBadge(packageName, badgeLabel, sortType);
     }
 }

--- a/src/test/groovy/io/github/devatherock/test/TestUtil.groovy
+++ b/src/test/groovy/io/github/devatherock/test/TestUtil.groovy
@@ -57,6 +57,28 @@ class TestUtil {
         }"""
     }
 
+    static String getSimilarFoldersResponse() {
+        """{
+            "repo": "docker",
+            "path": "docker/devatherock/simple-slack",
+            "created": "2020-10-01T00:00:00.000Z",
+            "createdBy": "devatherock",
+            "lastModified": "2020-10-01T00:00:00.000Z",
+            "modifiedBy": "devatherock",
+            "lastUpdated": "2020-10-01T00:00:00.000Z",
+            "children": [
+                {
+                    "uri": "/1.1.0-alpha",
+                    "folder": true
+                },
+                {
+                    "uri": "/1.1.0-beta",
+                    "folder": true
+                }
+            ]
+        }"""
+    }
+
     static String getFolderWithOnlyFileResponse() {
         """{
             "repo": "docker",


### PR DESCRIPTION
The default value is `date`. With value `semver`, it'll pull the latest out of only semantic version tags