### PR TITLE
feat: Added environment variable to accept logback config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,15 @@
 ### Added
 - [#51](https://github.com/devatherock/artifactory-badge/issues/51): Integration tests
 - [#14](https://github.com/devatherock/artifactory-badge/issues/14): Used native binary in docker image
+- [#159](https://github.com/devatherock/artifactory-badge/issues/159): Environment variable to accept logback config path. Needed as it wasn't clear how to set the JVM arg `logback.configurationFile` with the graalvm binary
 
 ### Changed
 - chore(deps): update plugin io.micronaut.application to v2.0.8
 - chore: Set renovate's email for changelog-updater plugin
-- chore(deps): update docker orb to v2.0.1
-- chore(deps): update plugin org.owasp.dependencycheck to 7.0.3
-- chore(deps): update dependency net.logstash.logback:logstash-logback-encoder to v7.0.1
-- chore(deps): update plugin com.diffplug.spotless to v6.0.1
-- chore(deps): updated logback to `1.2.10`
-- Upgraded micronaut to `3.4.1`
 - chore(deps): update dependency ch.qos.logback:logback-classic to v1.2.11
 - chore(deps): update dependency gradle to v6.9.2
-- chore(deps): update docker orb to v2.0.3
-- chore(deps): update plugin org.owasp.dependencycheck to v7.0.4.1
-- chore(deps): update dependency net.logstash.logback:logstash-logback-encoder to v7.1
-- chore(deps): update dependency io.micronaut:micronaut-bom to v3.4.2
 - chore(deps): update dependency net.logstash.logback:logstash-logback-encoder to v7.1.1
 - chore(deps): update dependency org.spockframework:spock-core to v2.1-groovy-3.0
-- chore(deps): update plugin com.diffplug.spotless to v6.4.2
 - chore(deps): update dependency cimg/openjdk to v17
 - chore: Used custom ssh key to push to github
 - chore(deps): update dependency io.micronaut:micronaut-bom to v3.4.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN native-image --no-server -cp build/libs/*-all.jar
 FROM frolvlad/alpine-glibc:alpine-3.12
 
 LABEL maintainer="devatherock@gmail.com"
-LABEL io.github.devatherock.version="0.6.0"
+LABEL io.github.devatherock.version="1.0.0"
 
 EXPOSE 8080
 RUN apk update \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ logger:
 | MICRONAUT_ENVIRONMENTS                |   false      |   (None)         |   Setting the value to `local` will mock the calls to the artifactory. Only for testing purposes  |
 | MICRONAUT_SERVER_PORT                 |   false      |   8080           |   Port in which the app listens on                                                |
 | MICRONAUT_CONFIG_FILES                |   true       |   (None)         |   Path to YAML config files. The YAML files can be used to specify complex, object and array properties  |
-| JAVA_OPTS                             |   false      |   (None)         |   Additional JVM arguments to be passed to the container's java process           |
+| LOGBACK_CONFIGURATION_FILE            |   false      |   (None)         |   Path to logback configuration file           |
 
 ### API spec
 When the app is running, detailed API documentation can be accessed at `{host}/swagger-ui` or `{host}/swagger/artifactory-badge-{version}.yml`. The available endpoints are listed below for reference:
@@ -79,7 +79,7 @@ When the app is running, detailed API documentation can be accessed at `{host}/s
 - Set the environment variable `LOGGER_LEVELS_ROOT` to `DEBUG` to enable all debug logs - custom and framework
 - Set the environment variable `LOGGER_LEVELS_IO_GITHUB_DEVATHEROCK` to `DEBUG` to enable debug logs only in custom code
 - For fine-grained logging control, supply a custom [logback.xml](http://logback.qos.ch/manual/configuration.html) file
-and set the environment variable `JAVA_OPTS` to `-Dlogback.configurationFile=/path/to/custom/logback.xml`
+and set the environment variable `LOGBACK_CONFIGURATION_FILE` to `/path/to/custom/logback.xml`
 
 ### JSON logs
-Refer [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder) documentation to customize the field names and formats in the log. To output logs as JSON, set the environment variable `JAVA_OPTS` to `-Dlogback.configurationFile=logback-json.xml`
+Refer [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder) documentation to customize the field names and formats in the log. To output logs as JSON, set the environment variable `LOGBACK_CONFIGURATION_FILE` to `logback-json.xml`

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'org.owasp.dependencycheck' version '7.1.0.1'
 }
 
-version "0.6.0"
+version "1.0.0"
 group "io.github.devatherock"
 sourceCompatibility = '11'
 targetCompatibility = '11'
@@ -57,8 +57,7 @@ dependencies {
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.1.1'
     implementation group: 'org.codehaus.janino', name: 'janino', version: '3.1.7'
     implementation group: 'javax.inject', name: 'javax.inject', version: '1'
-
-    runtimeOnly "ch.qos.logback:logback-classic:1.2.11"
+    implementation "ch.qos.logback:logback-classic:1.2.11"
 
     testAnnotationProcessor platform("io.micronaut:micronaut-bom:$micronautVersion")
     testAnnotationProcessor "io.micronaut:micronaut-inject-java"

--- a/src/main/java/io/github/devatherock/Application.java
+++ b/src/main/java/io/github/devatherock/Application.java
@@ -1,16 +1,41 @@
 package io.github.devatherock;
 
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
+import ch.qos.logback.core.util.StatusPrinter;
 import io.micronaut.runtime.Micronaut;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
 
-@OpenAPIDefinition(info = @Info(title = "artifactory-badge", version = "0.5.0"), servers = {
+@OpenAPIDefinition(info = @Info(title = "artifactory-badge", version = "1.0.0"), servers = {
         @Server(url = "http://localhost:8080", description = "The server where the application is hosted. Defaulted to localhost")
 })
 public class Application {
+    private static final String ENV_LOGBACK_CONFIG = "LOGBACK_CONFIGURATION_FILE";
 
     public static void main(String[] args) {
+        if (System.getProperty(ContextInitializer.CONFIG_FILE_PROPERTY) == null &&
+                System.getenv(ENV_LOGBACK_CONFIG) != null) {
+            LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+            try {
+                JoranConfigurator configurator = new JoranConfigurator();
+                configurator.setContext(context);
+                context.reset();
+                configurator.doConfigure(
+                        Application.class.getClassLoader().getResourceAsStream(System.getenv(
+                                ENV_LOGBACK_CONFIG)));
+            } catch (JoranException je) {
+                // StatusPrinter will handle this
+            }
+            StatusPrinter.printInCaseOfErrorsOrWarnings(context);
+        }
+
         Micronaut.run(Application.class);
     }
 }

--- a/src/main/resources/META-INF/native-image/io.github.devatherock/artifactory-badge/native-image.properties
+++ b/src/main/resources/META-INF/native-image/io.github.devatherock/artifactory-badge/native-image.properties
@@ -1,6 +1,6 @@
 Args = -H:ResourceConfigurationFiles=build/generated/resources/graalvm/resource-config.json \
        -H:Name=micronautgraalapp \
-       -H:ReflectionConfigurationFiles=build/graal/reflect-config.json \
+       -H:ReflectionConfigurationFiles=build/graal/reflect-config.json,build/resources/main/graal/reflect-config.json \
        --no-fallback \
        --allow-incomplete-classpath \
        --report-unsupported-elements-at-runtime \

--- a/src/main/resources/graal/reflect-config.json
+++ b/src/main/resources/graal/reflect-config.json
@@ -1,0 +1,8 @@
+[
+	{
+		"name": "net.logstash.logback.encoder.LogstashEncoder",
+		"allDeclaredFields": true,
+		"allDeclaredMethods": true,
+		"allDeclaredConstructors": true
+	}
+]


### PR DESCRIPTION
Closes #159. Needed as it wasn't clear how to set the JVM arg `logback.configurationFile` with the graalvm binary